### PR TITLE
chore: update iot_bridge component yml

### DIFF
--- a/components/iot_bridge/CHANGELOG.md
+++ b/components/iot_bridge/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ChangeLog
 
+## v0.7.2 - 2023.8.10
+
+### Enhancements
+
+- Update iot_bridge component yml, the idf component manager now supports uploading components with rules.
+
 ## v0.7.1 - 2023.8.1
 
 ### Enhancements

--- a/components/iot_bridge/idf_component.yml
+++ b/components/iot_bridge/idf_component.yml
@@ -1,4 +1,4 @@
-version: "0.7.1"
+version: "0.7.2"
 description: A smart bridge to make both ESP and the other MCU or smart device can access the Internet
 url: https://github.com/espressif/esp-iot-bridge/tree/master/components/iot_bridge
 repository: https://github.com/espressif/esp-iot-bridge.git
@@ -7,20 +7,20 @@ issues: https://github.com/espressif/esp-iot-bridge/issues
 dependencies:
   idf: ">=4.3"
   espressif/cmake_utilities: 0.*
-  # The "esp_modem_usb_dte" component is temporarily disabled, as idf-component-manager
-  # doesn't support uploading components with "rules" entries to the registry.
-  # Re-enable this after the bug fix in idf-component-manager is released,
-  # and increase the component version to 0.2.1.
-  #
-  # espressif/esp_modem:
-  #   version: 1.*
-  #   rules:
-  #     - if: "target not in [esp32s2, esp32s3]"
-  # espressif/esp_modem_usb_dte:
-  #   version: 1.*
-  #   rules:
-  #     - if: "target in [esp32s2, esp32s3]"
-  #     - if: "idf_version >=4.4"
+  espressif/esp_modem:
+    version: 1.*
+    rules:
+      - if: "target not in [esp32s2, esp32s3]"
+  espressif/esp_modem_usb_dte:
+    version: 1.*
+    rules:
+      - if: "target in [esp32s2, esp32s3]"
+      - if: "idf_version >=4.4"
+  usb_device:
+    path: components/usb/usb_device
+    git: https://github.com/espressif/esp-iot-bridge.git
+    rules:
+      - if: "target in [esp32s2, esp32s3]"
 examples:
   - path: ../../examples/wifi_router
   - path: ../../examples/wireless_nic

--- a/examples/4g_hotspot/main/idf_component.yml
+++ b/examples/4g_hotspot/main/idf_component.yml
@@ -4,25 +4,3 @@ dependencies:
     version: "*"
     # Please comment the following line, if this example is installed by idf.py create-project-from-example.
     override_path: "../../../components/iot_bridge"
-  # Wait until the `usb_device` component is listed in the package manager
-  # before adding the dependency to the `yml` file of the `iot_bridge` component.
-  #
-  usb_device:
-    path: components/usb/usb_device
-    git: https://github.com/espressif/esp-iot-bridge.git
-    rules:
-      - if: "target in [esp32s2, esp32s3]"
-  # The "esp_modem_usb_dte" component is temporarily disabled in iot_bridge yml file,
-  # as idf-component-manager doesn't support uploading components with "rules" entries to the registry.
-  # So temporarily place the "esp_modem_usb_dte" "esp_modem" component under examples.
-  #
-  espressif/esp_modem:
-    version: 1.*
-    rules:
-      - if: "target not in [esp32s2, esp32s3]"
-  espressif/esp_modem_usb_dte:
-    version: 1.*
-    public: true
-    rules:
-      - if: "target in [esp32s2, esp32s3]"
-      - if: "idf_version >=4.4"

--- a/examples/4g_nic/main/idf_component.yml
+++ b/examples/4g_nic/main/idf_component.yml
@@ -4,25 +4,3 @@ dependencies:
     version: "*"
     # Please comment the following line, if this example is installed by idf.py create-project-from-example.
     override_path: "../../../components/iot_bridge"
-  # Wait until the `usb_device` component is listed in the package manager
-  # before adding the dependency to the `yml` file of the `iot_bridge` component.
-  #
-  usb_device:
-    path: components/usb/usb_device
-    git: https://github.com/espressif/esp-iot-bridge.git
-    rules:
-      - if: "target in [esp32s2, esp32s3]"
-  # The "esp_modem_usb_dte" component is temporarily disabled in iot_bridge yml file,
-  # as idf-component-manager doesn't support uploading components with "rules" entries to the registry.
-  # So temporarily place the "esp_modem_usb_dte" "esp_modem" component under examples.
-  #
-  espressif/esp_modem:
-    version: 1.*
-    rules:
-      - if: "target not in [esp32s2, esp32s3]"
-  espressif/esp_modem_usb_dte:
-    version: 1.*
-    public: true
-    rules:
-      - if: "target in [esp32s2, esp32s3]"
-      - if: "idf_version >=4.4"

--- a/examples/wifi_router/main/idf_component.yml
+++ b/examples/wifi_router/main/idf_component.yml
@@ -11,25 +11,3 @@ dependencies:
   web_server:
     path: components/web_server
     git: https://github.com/espressif/esp-iot-bridge.git
-  # Wait until the `usb_device` component is listed in the package manager
-  # before adding the dependency to the `yml` file of the `iot_bridge` component.
-  #
-  usb_device:
-    path: components/usb/usb_device
-    git: https://github.com/espressif/esp-iot-bridge.git
-    rules:
-      - if: "target in [esp32s2, esp32s3]"
-  # The "esp_modem_usb_dte" component is temporarily disabled in iot_bridge yml file,
-  # as idf-component-manager doesn't support uploading components with "rules" entries to the registry.
-  # So temporarily place the "esp_modem_usb_dte" "esp_modem" component under examples.
-  #
-  espressif/esp_modem:
-    version: 1.*
-    rules:
-      - if: "target not in [esp32s2, esp32s3]"
-  espressif/esp_modem_usb_dte:
-    version: 1.*
-    public: true
-    rules:
-      - if: "target in [esp32s2, esp32s3]"
-      - if: "idf_version >=4.4"

--- a/examples/wired_nic/main/idf_component.yml
+++ b/examples/wired_nic/main/idf_component.yml
@@ -4,25 +4,3 @@ dependencies:
     version: "*"
     # Please comment the following line, if this example is installed by idf.py create-project-from-example.
     override_path: "../../../components/iot_bridge"
-  # Wait until the `usb_device` component is listed in the package manager
-  # before adding the dependency to the `yml` file of the `iot_bridge` component.
-  #
-  usb_device:
-    path: components/usb/usb_device
-    git: https://github.com/espressif/esp-iot-bridge.git
-    rules:
-      - if: "target in [esp32s2, esp32s3]"
-  # The "esp_modem_usb_dte" component is temporarily disabled in iot_bridge yml file,
-  # as idf-component-manager doesn't support uploading components with "rules" entries to the registry.
-  # So temporarily place the "esp_modem_usb_dte" "esp_modem" component under examples.
-  #
-  espressif/esp_modem:
-    version: 1.*
-    rules:
-      - if: "target not in [esp32s2, esp32s3]"
-  espressif/esp_modem_usb_dte:
-    version: 1.*
-    public: true
-    rules:
-      - if: "target in [esp32s2, esp32s3]"
-      - if: "idf_version >=4.4"

--- a/examples/wireless_nic/main/idf_component.yml
+++ b/examples/wireless_nic/main/idf_component.yml
@@ -11,25 +11,3 @@ dependencies:
   web_server:
     path: components/web_server
     git: https://github.com/espressif/esp-iot-bridge.git
-  # Wait until the `usb_device` component is listed in the package manager
-  # before adding the dependency to the `yml` file of the `iot_bridge` component.
-  #
-  usb_device:
-    path: components/usb/usb_device
-    git: https://github.com/espressif/esp-iot-bridge.git
-    rules:
-      - if: "target in [esp32s2, esp32s3]"
-  # The "esp_modem_usb_dte" component is temporarily disabled in iot_bridge yml file,
-  # as idf-component-manager doesn't support uploading components with "rules" entries to the registry.
-  # So temporarily place the "esp_modem_usb_dte" "esp_modem" component under examples.
-  #
-  espressif/esp_modem:
-    version: 1.*
-    rules:
-      - if: "target not in [esp32s2, esp32s3]"
-  espressif/esp_modem_usb_dte:
-    version: 1.*
-    public: true
-    rules:
-      - if: "target in [esp32s2, esp32s3]"
-      - if: "idf_version >=4.4"


### PR DESCRIPTION
The idf component manager now supports uploading components with rules.

# Checklist for new Board Support package or Component

- [ ] Component contains License
- [ ] Component contains README.md
- [ ] Project [README.md](../README.md) updated
- [ ] Component contains idf_component.yml file with `url` field defined
- [ ] Component was added to CI [upload job](https://github.com/espressif/esp-iot-bridge/blob/master/.github/workflows/upload_component.yml#L17)
- [ ] New files were added to CI build job
- [ ] _Optional:_ Component contains unit tests
- [ ] CI passing

# Change description
_Please describe your change here_
